### PR TITLE
Fixed BLOB storage permission error?

### DIFF
--- a/.github/workflows/release_docker_jar.yml
+++ b/.github/workflows/release_docker_jar.yml
@@ -21,7 +21,7 @@ jobs:
           name: sync_job.jar
           path: lib/
       - name: Build image
-        run: docker build . -f docker/Dockerfile -t syncjob
+        run: docker build . -f docker/Dockerfile -t syncjob --target package-ci
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
       - name: Push image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,22 @@
-FROM flink:1.11.2-scala_2.12
+#########################
+# Stage 1: sbt assembly #
+#########################
 
+FROM mozilla/sbt:8u232_1.4.9 AS assembly
+WORKDIR /home
+COPY . .
+RUN sbt assembly
+
+#######################
+# Stage 2a: packaging #
+#######################
+
+FROM flink:1.11.2-scala_2.12 AS package
+COPY --from=assembly /home/lib/sync_job.jar /opt/flink/usrlib/
+
+###################################################
+# Stage 2b: packaging in CI (jar already present) #
+###################################################
+
+FROM flink:1.11.2-scala_2.12 AS package-ci
 ADD lib/sync_job.jar /opt/flink/usrlib/


### PR DESCRIPTION
My attempt to fix https://github.com/fasten-project/fasten-docker-deployment/issues/7 started with a Dockerfile stage to build the JAR, just for my convenience...:

https://github.com/fasten-project/synchronize-javacg/blob/336b26ad9a448b0912b2958c5b68a23964ec948a/docker/Dockerfile#L1-L8

Then I'm using the following stage to retrieve the previously-assembled JAR in my docker-compose deployment:

https://github.com/fasten-project/synchronize-javacg/blob/336b26ad9a448b0912b2958c5b68a23964ec948a/docker/Dockerfile#L10-L15

This stage only exists not to break the CI:

https://github.com/fasten-project/synchronize-javacg/blob/336b26ad9a448b0912b2958c5b68a23964ec948a/docker/Dockerfile#L17-L22

(Notice the `--target` flag here:)

https://github.com/fasten-project/synchronize-javacg/blob/336b26ad9a448b0912b2958c5b68a23964ec948a/.github/workflows/release_docker_jar.yml#L24

---

These are all my changes: for whatever reason, https://github.com/fasten-project/fasten-docker-deployment/issues/7 doesn't happen anymore.
I didn't change anything w.r.t. permissions, groups, etc., yet... I have no idea why this works.
@wzorgdrager thoughts?

---

#### Closing keyword

Closes https://github.com/fasten-project/fasten-docker-deployment/issues/7.