### PR TITLE
Added Dockerfile stage for JAR assembly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!project/build.properties
+!project/build.sbt
+!src/main/*
+!build.sbt

--- a/.github/workflows/release_docker_jar.yml
+++ b/.github/workflows/release_docker_jar.yml
@@ -21,7 +21,7 @@ jobs:
           name: sync_job.jar
           path: lib/
       - name: Build image
-        run: docker build . -f docker/Dockerfile -t syncjob --target package-ci
+        run: DOCKER_BUILDKIT=1 docker build . -f docker/Dockerfile -t syncjob --target package-ci
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
       - name: Push image

--- a/.github/workflows/release_docker_jar.yml
+++ b/.github/workflows/release_docker_jar.yml
@@ -21,7 +21,7 @@ jobs:
           name: sync_job.jar
           path: lib/
       - name: Build image
-        run: docker build . -f docker/Dockerfile -t syncjob
+        run: docker build . -f docker/Dockerfile -t syncjob --target package-ci
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
       - name: Push image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,22 @@
-FROM flink:1.11.2-scala_2.12
+#########################
+# Stage 1: sbt assembly #
+#########################
 
+FROM mozilla/sbt:8u232_1.4.9 AS assembly
+WORKDIR /home
+COPY . .
+RUN sbt assembly
+
+#######################
+# Stage 2a: packaging #
+#######################
+
+FROM flink:1.11.2-scala_2.12 AS package
+COPY --from=assembly /home/lib/sync_job.jar /opt/flink/usrlib/
+
+###################################################
+# Stage 2b: packaging in CI (jar already present) #
+###################################################
+
+FROM flink:1.11.2-scala_2.12 AS package-ci
 ADD lib/sync_job.jar /opt/flink/usrlib/


### PR DESCRIPTION
I was working on https://github.com/fasten-project/k8s-deployments/issues/22 and I might have to edit the base image of this sync job.

I added a target `package` which runs `sbt assembly` in a Dockerfile stage, as I don't want to install `sbt` on my local machine. With `.dockerignore`, one can leverage the Docker build cache more efficiently as `COPY . .` only copies the necessary files. The `package-ci` target makes it work in CI.

I've tested this already.